### PR TITLE
feat(turborepo):fix turborepo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,16 @@
   "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": ["^build","$NEXT_PUBLIC_DOCS_URL"],
-      "outputs": ["dist/**", ".next/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ],
+      "env": [
+        "NEXT_PUBLIC_DOCS_URL"
+      ]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
## Overview

When adding an env var to turborepo the linting and deployment failed, after some googling I found [this](https://stackoverflow.com/questions/73718867/turbo-no-undeclared-env-vars-not-recognizing-changes) Stack Overflow post that had my same problem, build failing because of the rule `turbo/no-undeclared-env-vars`

the solution was to add a new prop in the build object called `env` and add the env var there

Furthermore when running turborepo on Vercel you also get some extra useful info like a codemod to fix your turbo.json file in your case by running

```
npx @turbo/codemod migrate-env-var-dependencies
```

in the root folder you'd get the right props in the json file.
