### PR TITLE
feat(basic-api):Add simple enpoint to return data and simulate slow network connection

### DIFF
--- a/apps/basic/data/coffee-shops.ts
+++ b/apps/basic/data/coffee-shops.ts
@@ -1,0 +1,107 @@
+export type CoffeeShop = {
+    id: number;
+    name: string;
+    image: string;
+    address: Address;
+};
+
+export type Address = {
+    street: string;
+    streetName: string;
+    buildingNumber: string;
+    city: string;
+    zipcode: string;
+    country: string;
+    county_code: string;
+    latitude: number;
+    longitude: number;
+    id?: number;
+};
+
+const data = [
+    {
+        id: 1,
+        name: "Doctor Bean",
+        image: "https://placeimg.com/640/480/arch",
+        address: {
+            street: "614 Easter Land",
+            streetName: "Treutel Prairie",
+            buildingNumber: "34509",
+            city: "Lake Hardyfurt",
+            zipcode: "24030-6385",
+            country: "Western Sahara",
+            county_code: "NC",
+            latitude: 72.86095,
+            longitude: -137.096463,
+        },
+    },
+
+    {
+        id: 2,
+        name: " Wicked Java",
+        image: "https://placeimg.com/640/480/arch",
+        address: {
+            street: "8316 Rocio Crossing Apt. 721",
+            streetName: "Schamberger Cliffs",
+            buildingNumber: "576",
+            city: "Sauertown",
+            zipcode: "76373-8712",
+            country: "Germany",
+            county_code: "CL",
+            latitude: 37.16631,
+            longitude: 152.396919,
+        },
+    },
+
+    {
+        id: 3,
+        name: "",
+        image: "https://placeimg.com/640/480/arch",
+        address: {
+            street: "53311 Upton Squares",
+            streetName: "Patience Streets",
+            buildingNumber: "3855",
+            city: "North Samara",
+            zipcode: "87161-3083",
+            country: "Switzerland",
+            county_code: "AU",
+            latitude: -86.070607,
+            longitude: 9.29648,
+        },
+    },
+    {
+        id: 4,
+        name: " Brew Planet",
+        image: "https://placeimg.com/640/480/arch",
+        address: {
+            id: 0,
+            street: "2231 Jace Fields",
+            streetName: "Adrianna Courts",
+            buildingNumber: "80952",
+            city: "North Raoulburgh",
+            zipcode: "82110-8821",
+            country: "Slovakia (Slovak Republic)",
+            county_code: "MP",
+            latitude: -47.236628,
+            longitude: 144.406981,
+        },
+    },
+    {
+        id: 5,
+        name: "Posh Bean",
+        image: "https://placeimg.com/640/480/arch",
+        address: {
+            street: "495 Boris Locks Apt. 203",
+            streetName: "Brendan Pike",
+            buildingNumber: "886",
+            city: "New Brennon",
+            zipcode: "19431",
+            country: "Malta",
+            county_code: "KP",
+            latitude: 27.082771,
+            longitude: -104.070119,
+        },
+    },
+] as const;
+
+export default data;

--- a/apps/basic/pages/api/coffee-shops.ts
+++ b/apps/basic/pages/api/coffee-shops.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import coffeeShops from "../../data/coffee-shops";
+
+type ThrottleType = "minimal" | "aggressive" | "none";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const throttling = req.query?.throttling?.toString() ?? "none";
+  await getThrottlePromise(throttling);
+  res.status(200).json(coffeeShops);
+}
+
+function getThrottlePromise(level: ThrottleType | string): Promise<void> {
+  switch (level) {
+    case "minimal":
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+    case "aggressive":
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 5000);
+      });
+    case "none":
+    default:
+      return Promise.resolve();
+  }
+}


### PR DESCRIPTION
### Overview

This PR adds a simple endpoint that returns a list of 5 coffee shops, the data has been generated through Faker, so addresses and locations don't have a secondary meaning than just being test data.

The endpoint accepts a query parameter called `throttling` which will be used to slow down the response and demonstrate slow endpoints, possible options are:

`/api/coffee-shops?throttling=minimal` wait 1 second before sending the request
`/api/coffee-shops?throttling=aggressive` wait 5 seconds before sending the request
`/api/coffee-shops?throttling=none` `none`, any other value or no parameter at all will not add any artificial delay to the response
